### PR TITLE
Vulcan TKL: fix `table index is nil` exception

### DIFF
--- a/eruption/src/scripts/lib/hwdevices/keyboards/roccat_vulcan_tkl.lua
+++ b/eruption/src/scripts/lib/hwdevices/keyboards/roccat_vulcan_tkl.lua
@@ -66,6 +66,11 @@ key_to_index['DEL'] = 102
 key_to_index['END'] = 106
 key_to_index['PGDWN'] = 111
 
+key_to_index['UP'] = 91
+key_to_index['DOWN'] = 92
+key_to_index['LEFT'] = 87
+key_to_index['RIGHT'] = 96
+
 key_to_index['1'] = 7
 key_to_index['2'] = 13
 key_to_index['3'] = 19


### PR DESCRIPTION
Fixes the folowing exception

```
Lua error in file /usr/share/eruption/scripts/macros.lua: runtime error: ...n/scripts//lib/hwdevices/keyboards/roccat_vulcan_tkl.lua:91: table index is nil
                                                stack traceback:
                                                        [C]: in metamethod '__newindex'
                                                        ...n/scripts//lib/hwdevices/keyboards/roccat_vulcan_tkl.lua:91: in function 'device_specific_key_highlights'
                                                        /usr/share/eruption/scripts//lib/macros/user-macros.lua:293: in function 'update_color_state'
                                                        [string "eruption/src/scripting/script.rs:249:40"]:716: in function 'on_tick'
                                                        UnknownError
```