### PR TITLE
feat: add Chaotic-AUR as binary source for Arch devriates

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ systemctl --user enable --now eruption-process-monitor.service
 
 sudo systemctl enable --now eruption.service
 ```
+Additionally, [Chaotic-AUR](https://aur.chaotic.cx) is providing pre-compiled binaries for those who don't want to go through the compilation process with every update.
 
 ### Fedora based
 


### PR DESCRIPTION
Hi! :)

I am one of the maintainers of Chaotic-AUR, a binary repository for AUR packages. 
Since this is a great project, I just added it to our package lists. This basically means the AUR package is used as a PKGBUILD source to add it to the repository, updated hourly. 

https://github.com/chaotic-aur/packages/commit/534462788eaa94803d315ea5a13f5845377e2773

Making this piece of information available to everyone can help people with tremendously slow PCs or internet connections since the compilation process is no longer needed 😁