### PR TITLE
feat: add initial NixOS flake (WIP)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699343069,
+        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "path": "/nix/store/mj0hy52z22q5gpsf33akndxiclxd8ray-source",
+        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1699725108,
+        "narHash": "sha256-NTiPW4jRC+9puakU4Vi8WpFEirhp92kTOSThuZke+FA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "911ad1e67f458b6bcf0278fa85e33bb9924fed7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,105 @@
+{
+  # Eruption NixOS flake
+  inputs = {
+    naersk.url = "github:nix-community/naersk/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    naersk,
+    nixpkgs,
+    self,
+    utils,
+  }:
+  # We do this for all systems - namely x86_64-linux, aarch64-linux,
+  # x86_64-darwin and aarch64-darwin
+    utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      naersk-lib = pkgs.callPackage naersk {};
+
+      eruption = pkgs.rustPlatform.buildRustPackage rec {
+        pname = "eruption";
+        version = "3119861a912fc976c4b24cfee5e41f6c32bf75c2";
+        src = pkgs.fetchFromGitHub {
+          owner = "eruption-project";
+          repo = pname;
+          rev = version;
+          hash = "sha256-J3ov5izyachxw6g/Bx/nFsSRotN4qT1LTWAR0JQJyFs=";
+        };
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "hidapi-2.4.1" = "sha256-jzZalweZRr/Ob+7XhHFFruPEXzmSkYZLP5RhdNq9CE4=";
+            "rust-pulsectl-0.2.7" = "sha256-jkZJiTbCkPCe20d08ExY/VmdFOaV3GxMxMVOnXl2HlM=";
+          };
+        };
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          protobuf
+          installShellFiles
+          libxkbcommon
+        ];
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+        buildInputs = with pkgs; [
+          dbus
+          gcc
+          gtk3
+          gtk3
+          gtksourceview4
+          hidapi
+          libxkbcommon
+          libevdev
+          libpulseaudio
+          libusb1
+          lua
+          lua54Packages.luasocket
+          systemd
+        ];
+        postInstall = ''
+          installManPage support/man/*.{8,5,1}
+          installShellCompletion --bash support/shell/completions/en_US/*.bash-completion
+          installShellCompletion --fish support/shell/completions/en_US/*.fish-completion
+          installShellCompletion --zsh support/shell/completions/en_US/*.zsh-completion
+        '';
+      };
+    in rec {
+      # Build via "nix build .#default"
+      packages = {
+        default = eruption;
+        eruption_git = naersk-lib.buildPackage {
+          # The build dependencies
+          buildInputs = with pkgs; [
+            cmake
+            dbus
+            gcc
+            gtk3
+            gtk3
+            gtksourceview4
+            hidapi
+            libevdev
+            libpulseaudio
+            libusb1
+            lua
+            lua54Packages.luasocket
+            pkgconf
+            protobuf
+            systemd
+            xorg.xrandr
+            xorg.xorgserver
+          ];
+          src = ./.;
+        };
+        inherit eruption;
+      };
+      # Enter devshell with all the tools via "nix develop"
+      # or "nix-shell"
+      devShells.default = with pkgs;
+        mkShell {
+          buildInputs = [
+            git
+            eruption
+          ];
+        };
+    });
+}


### PR DESCRIPTION
This PR adds a NixOS flake, which provides the `eruption` package. 

Done:
- Building `eruption` package via `rustPlatform.buildRustPackage`

To-do: 
- Add Systemd units via Nix functions
- Add the package to either [Nixpkgs](https://github.com/NixOS/nixpkgs) or [Chaotic Nyx](https://github.com/chaotic-cx/nyx)
- Fix Nearsk build (currently errors out, perfect for adding a bleeding edge `eruption_git` package as flake input though)